### PR TITLE
Specify explicit type parameters for middleware in test/greencat_test.dart

### DIFF
--- a/test/greencat_test.dart
+++ b/test/greencat_test.dart
@@ -48,7 +48,7 @@ void main() {
 
     test('adds middleware', () async {
       store
-        ..addMiddleware(const ThunkMiddleware())
+        ..addMiddleware(const ThunkMiddleware<TodoState, TodoAction>())
         ..dispatch(asyncAddTodo('thunk!'));
       await store.stream.first;
 
@@ -57,7 +57,8 @@ void main() {
     });
 
     test('logging middleware sends messages', () async {
-      store.addMiddleware(new LoggingMiddleware(Logger.root));
+      store.addMiddleware(
+          new LoggingMiddleware<TodoState, TodoAction>(Logger.root));
       final logRecords = <LogRecord>[];
       Logger.root
         ..level = Level.FINE
@@ -112,7 +113,8 @@ void main() {
 
     test('adds middleware', () async {
       store
-        ..addMiddleware(const ThunkMiddleware())
+        ..addMiddleware(const ThunkMiddleware<
+            Tuple2<Iterable<Todo>, VisibilityFilter>, TodoAction>())
         ..dispatch(asyncAddTodo('thunk!'));
       await store.stream.first;
 


### PR DESCRIPTION
Currently the correct type parameters are inferred from the context.
However, an upcoming Dart 2.0 language change
(https://github.com/dart-lang/sdk/issues/32152) will break the
connection between callable classes and their corresponding function
types, which will prevent type inference from being able to infer
these type parameters anymore.

To prepare for the language change, we need to specify the type
parameters explicitly.