### PR TITLE
Migrating to Dart 2

### DIFF
--- a/example/todo_list_angular/pubspec.yaml
+++ b/example/todo_list_angular/pubspec.yaml
@@ -2,7 +2,7 @@ name: todo_list_angular
 description: A Dart app that uses Angular 2
 version: 0.0.1
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 dependencies:
   angular2: 3.0.0
   browser: ^0.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: greencat
 description: A port of Redux to Dart, including Redux Thunk and a simple Logger.
-version: 0.1.4
+version: 0.2.0
 author: Alexei Diaz <alexei.eleusis@gmail.com>
 homepage: https://github.com/alexeieleusis/greencat
 
 environment:
-  sdk: ">=1.23.0 <2.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   logging: ">=0.11.3 <0.12.0"
   tuple: ">=1.0.1 <2.0.0"
 
 dev_dependencies:
-  test: '>=0.12.0 <0.13.0'
+  test: '>=1.5.1 <2.0.0'
   todo_list:
     path: testing/todo_list

--- a/testing/todo_list/pubspec.yaml
+++ b/testing/todo_list/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 #homepage: https://www.example.com
 
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   greencat:


### PR DESCRIPTION
Users of Dart 1 should use previous versions.

Fixes https://github.com/alexeieleusis/greencat/issues/23